### PR TITLE
Fix webhook URL and lint errors

### DIFF
--- a/src/components/MarkdownDisplay.tsx
+++ b/src/components/MarkdownDisplay.tsx
@@ -12,23 +12,33 @@ export function MarkdownDisplay({ content }: MarkdownDisplayProps) {
       <ReactMarkdown 
         remarkPlugins={[remarkGfm]}
         components={{
-          h1: ({node, ...props}) => <h1 className="text-2xl font-bold mt-6 mb-4 dark:text-white" {...props} />,
-          h2: ({node, ...props}) => <h2 className="text-xl font-semibold mt-5 mb-3 dark:text-gray-200" {...props} />,
-          h3: ({node, ...props}) => <h3 className="text-lg font-medium mt-4 mb-2 dark:text-gray-300" {...props} />,
-          p: ({node, ...props}) => <p className="my-2 dark:text-gray-300" {...props} />,
-          a: ({node, ...props}) => (
-            <a 
-              className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline" 
-              target="_blank" 
-              rel="noopener noreferrer" 
-              {...props} 
+          h1: ({ ...props }) => (
+            <h1 className="text-2xl font-bold mt-6 mb-4 dark:text-white" {...props} />
+          ),
+          h2: ({ ...props }) => (
+            <h2 className="text-xl font-semibold mt-5 mb-3 dark:text-gray-200" {...props} />
+          ),
+          h3: ({ ...props }) => (
+            <h3 className="text-lg font-medium mt-4 mb-2 dark:text-gray-300" {...props} />
+          ),
+          p: ({ ...props }) => <p className="my-2 dark:text-gray-300" {...props} />,
+          a: ({ ...props }) => (
+            <a
+              className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline"
+              target="_blank"
+              rel="noopener noreferrer"
+              {...props}
             />
           ),
-          ul: ({node, ...props}) => <ul className="list-disc ml-4 my-2 dark:text-gray-300" {...props} />,
-          ol: ({node, ...props}) => <ol className="list-decimal ml-4 my-2 dark:text-gray-300" {...props} />,
-          li: ({node, ...props}) => <li className="my-1" {...props} />,
-          hr: ({node, ...props}) => <hr className="my-4 border-gray-200 dark:border-gray-700" {...props} />,
-          strong: ({node, ...props}) => <strong className="font-semibold dark:text-gray-200" {...props} />,
+          ul: ({ ...props }) => <ul className="list-disc ml-4 my-2 dark:text-gray-300" {...props} />,
+          ol: ({ ...props }) => <ol className="list-decimal ml-4 my-2 dark:text-gray-300" {...props} />,
+          li: ({ ...props }) => <li className="my-1" {...props} />,
+          hr: ({ ...props }) => (
+            <hr className="my-4 border-gray-200 dark:border-gray-700" {...props} />
+          ),
+          strong: ({ ...props }) => (
+            <strong className="font-semibold dark:text-gray-200" {...props} />
+          ),
         }}
       >
         {content}

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,3 +1,4 @@
 export const API_CONFIG = {
-  WEBHOOK_URL: 'https://n8.ngnc.co.uk/webhook-test/1a830376-1355-42a5-'
+  WEBHOOK_URL:
+    'https://n8.ngnc.co.uk/webhook-test/1a830376-1355-42a5-9fc0-fb1b9bc4d1fe',
 } as const;


### PR DESCRIPTION
## Summary
- correct the webhook URL in API config
- clean up unused `node` prop in `MarkdownDisplay`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68417960293c832ca5941af137a7486d